### PR TITLE
POI fixes

### DIFF
--- a/FixEyeMov.com3d2/MiscPatches.cs
+++ b/FixEyeMov.com3d2/MiscPatches.cs
@@ -24,9 +24,9 @@ namespace Karenia.FixEyeMov.Com3d2
             HarmonyLib.Harmony harmony,
             BepInEx.Logging.ManualLogSource logger)
         {
-            var getSlotLoadedMethod = AccessTools.Method(typeof(TBody), "GetSlotLoaded");
             if (gameVersion < 1560)
             {
+                var getSlotLoadedMethod = AccessTools.Method(typeof(TBody), "GetSlotLoaded");
                 harmony.Patch(getSlotLoadedMethod, prefix: new HarmonyMethod(AccessTools.Method(typeof(MiscPatches), nameof(LoadSlotBoundsCheck))));
             }
         }

--- a/FixEyeMov.com3d2/Plugin.cs
+++ b/FixEyeMov.com3d2/Plugin.cs
@@ -79,6 +79,8 @@ namespace Karenia.FixEyeMov.Com3d2
                 Logger.LogDebug("Patching POI stuff");
                 harmony.PatchAll(typeof(Poi.PoiHook));
                 Poi.PoiHook.PatchKagSceneTags(harmony);
+                Poi.PoiHook.PatchInitPoiInfo(harmony);
+                Poi.PoiHook.Init();
             }
             catch (Exception e)
             {

--- a/FixEyeMov.com3d2/PointOfInterest.cs
+++ b/FixEyeMov.com3d2/PointOfInterest.cs
@@ -343,9 +343,13 @@ namespace Karenia.FixEyeMov.Com3d2.Poi
         /// <param name="harmony"></param>
         public static void PatchMaidVoicePitch(Harmony harmony)
         {
-            var assembly = System.Reflection.Assembly.Load("COM3D2.MaidVoicePitch.Plugin");
             ManualLogSource? logger = Plugin.Instance?.Logger;
-            if (assembly == null)
+
+            try
+            {
+                 var assembly = System.Reflection.Assembly.Load("COM3D2.MaidVoicePitch.Plugin");
+            }
+            catch (System.IO.FileNotFoundException e)
             {
                 logger?.LogInfo("MaidVoicePitch not found. Exiting.");
                 return;

--- a/FixEyeMov.com3d2/PointOfInterest.cs
+++ b/FixEyeMov.com3d2/PointOfInterest.cs
@@ -39,10 +39,53 @@ namespace Karenia.FixEyeMov.Com3d2.Poi
     internal static class InterestedTransform
     {
         private static readonly FieldInfo jiggleBoneSubject = AccessTools.Field(typeof(jiggleBone), "m_trSub");
+        private static readonly PropertyInfo dbMuneLProperty = AccessTools.Property(typeof(TBody), "dbMuneL");
+        private static readonly PropertyInfo dbMuneRProperty = AccessTools.Property(typeof(TBody), "dbMuneR");
+        private static readonly FieldInfo dynamicMuneBoneSubject = null;
 
-        public static Transform? LeftBreast(TBody body) => (Transform)jiggleBoneSubject.GetValue(body.jbMuneL);
+        static InterestedTransform()
+        {
+            if (dbMuneLProperty != null)
+            {
+                dynamicMuneBoneSubject = AccessTools.Field(dbMuneLProperty.PropertyType, "MuneSub");
+            }
+        }
 
-        public static Transform? RightBreast(TBody body) => (Transform)jiggleBoneSubject.GetValue(body.jbMuneR);
+        public static Transform? LeftBreast(TBody body)
+        {
+            if (!body.maid.IsCrcBody)
+            {
+                return (Transform)jiggleBoneSubject.GetValue(body.jbMuneL);
+            }
+            else
+            {
+                var dbMuneL = dbMuneLProperty.GetValue(body, null);
+                if (dbMuneL != null)
+                {
+                    return (Transform)dynamicMuneBoneSubject.GetValue(dbMuneL);
+                }
+            }
+
+            return null;
+        }
+
+        public static Transform? RightBreast(TBody body)
+        {
+            if (!body.maid.IsCrcBody)
+            {
+                return (Transform)jiggleBoneSubject.GetValue(body.jbMuneR);
+            }
+            else
+            {
+                var dbMuneR = dbMuneRProperty.GetValue(body, null);
+                if(dbMuneR != null)
+                {
+                    return (Transform)dynamicMuneBoneSubject.GetValue(dbMuneR);
+                }
+            }
+
+            return null;
+        }
 
         public static Transform? Genitalia(TBody body) => body.Pelvis.transform;
 

--- a/FixEyeMov.com3d2/PointOfInterest.cs
+++ b/FixEyeMov.com3d2/PointOfInterest.cs
@@ -514,10 +514,23 @@ namespace Karenia.FixEyeMov.Com3d2.Poi
         public static void AddCameraTarget(Maid __instance)
         {
             if (!poiRepo.TryGetValue(__instance.body0, out var poi)) return;
-            CameraTarget target = new CameraTarget();
-            // main targets should be replacing each other, thus the same name
-            poi.AddPoi("target", new PointOfInterest(target, 2, true));
-            poi.MainTarget = target;
+            if (__instance.body0.trsLookTarget is null)
+            {
+                Plugin.Instance?.Logger.LogInfo($"{__instance} target reset");
+                RemoveTarget(__instance);
+            }
+            else if (!__instance.body0.boEyeToCam)
+            {
+                Plugin.Instance?.Logger.LogInfo($"{__instance} reset EyeToCamera due movetype");
+                RemoveTarget(__instance);
+            }
+            else
+            {
+                CameraTarget target = new CameraTarget();
+                // main targets should be replacing each other, thus the same name
+                poi.AddPoi("target", new PointOfInterest(target, 2, true));
+                poi.MainTarget = target;
+            }
         }
 
         [HarmonyPostfix, HarmonyPatch(typeof(Maid), "EyeToPosition")]

--- a/FixEyeMov.com3d2/PointOfInterest.cs
+++ b/FixEyeMov.com3d2/PointOfInterest.cs
@@ -510,6 +510,25 @@ namespace Karenia.FixEyeMov.Com3d2.Poi
             }
         }
 
+        [HarmonyPostfix, HarmonyPatch(typeof(Maid), "EyeToTargetObject")]
+        public static void AddTarget(Maid __instance, Transform target_trans, float f_fFadeTime)
+        {
+            if (!poiRepo.TryGetValue(__instance.body0, out var poi)) return;
+            // Chances are the null target is intentional, as seen in the source code
+            if (__instance.body0.trsLookTarget == null)
+            {
+                RemoveTarget(__instance);
+            }
+            else
+            {
+                TransformTarget target = new TransformTarget(__instance.body0.trsLookTarget);
+                Plugin.Instance?.Logger.LogInfo($"{__instance} new object ransform target {__instance.body0.trsLookTarget}");
+                // main targets should be replacing each other, thus the same name
+                poi.AddPoi("target", new PointOfInterest(target, 2, true));
+                poi.MainTarget = target;
+            }
+        }
+
         [HarmonyPostfix, HarmonyPatch(typeof(Maid), "EyeToCamera")]
         public static void AddCameraTarget(Maid __instance)
         {


### PR DESCRIPTION
This PR fixes the POI system for com3d2

- Fix eyes rolling back on certain scenes (due to destroyed/invalid targets). Also fixes resulting log spam.
- Double check look target call parameters and only set camera as target based on that (since the function is also called when resetting the maid's look target). Fixes maid always looking at camera when specifically set not to do so.
- Adds support for COM3D2.5 POI targets